### PR TITLE
modify failing logic

### DIFF
--- a/src/visiumlint/main.py
+++ b/src/visiumlint/main.py
@@ -1,4 +1,5 @@
 """visiumlint main module."""
+# pylint: disable=duplicate-code
 import sys
 from subprocess import run
 
@@ -26,6 +27,7 @@ def lint() -> None:
             "--max-line-length",
             "120",
         ],
+        check=False,
     ).returncode
 
     run(["sh", "-c", "echo Running pydocstyle"], check=False)


### PR DESCRIPTION
Issue https://github.com/VisiumCH/visium-lint/issues/3

## Description

Visiumlint should first run all subprocesses before failing (instead of fast fail at the first possible error), by doing so the engineer would be able to observe all printed error messages and correct those, without needing to reiterate multiple times.

- change call() to run(), according to the [docs](https://docs.python.org/3/library/subprocess.html#subprocess.run) this is the modern way of calling a subprocess
- specify check flag to False to fail silently, this is required by [pylint](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/subprocess-run-check.html)
- collect the returncodes and determine the exit based on these values
