### PR TITLE
Feature/pre hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: visiumlint
+  name: visiumlint
+  description: Run visiumlint without Pylint
+  entry: visiumlint --hook
+  language: python
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Visiumlint relies on `black`, `isort`, `pylint`, `pydocstyle` and `mypy`.
 
 # Hook
 
-You can automate visiumlint when commiting changes with a [git hook](https://githooks.com/) and the [pre-commit](https://pre-commit.com/) library.
+You can automate visiumlint when commiting changes with a [git hook](https://githooks.com/) and the [pre-commit](https://pre-commit.com/) library. The hook will not execute `Pylint`.
 
-- Make sure to have installed pre-commit, or else run `brew install pre-commit`
+- Make sure to have installed pre-commit, or else run `pip install pre-commit`
 
 - Add a file called `.pre-commit-config.yaml` to the root of your project:
 ```yaml
@@ -29,15 +29,6 @@ repos:
       rev: 1.6.0
       hooks:
       -     id: visiumlint
-            language: python
-            types: [python]
-            require_serial: true
-
--     repo: local
-      hooks:
-      -     id: pylint
-            name: pylint
-            entry: pylint
             language: python
             types: [python]
             require_serial: true

--- a/README.md
+++ b/README.md
@@ -16,7 +16,33 @@ Visiumlint relies on `black`, `isort`, `pylint`, `pydocstyle` and `mypy`.
 - Activate the environment using `pipenv shell`
 - Run the visium package by running the command `visiumlint`
 
+# Hook
 
+You can automate visiumlint when commiting changes with a [git hook](https://githooks.com/) and the [pre-commit](https://pre-commit.com/) library.
+
+- Make sure to have installed pre-commit, or else run `brew install pre-commit`
+
+- Add a file called `.pre-commit-config.yaml` to the root of your project:
+```yaml
+repos:
+-     repo: https://github.com/VisiumCH/visiumlint
+      rev: 1.6.0
+      hooks:
+      -     id: visiumlint
+            language: python
+            types: [python]
+            require_serial: true
+
+-     repo: local
+      hooks:
+      -     id: pylint
+            name: pylint
+            entry: pylint
+            language: python
+            types: [python]
+            require_serial: true
+```
+- Run `pre-commit autoupdate`. This will use the latest available version of visiumlint.
 # Development
 ## Manage your python environment
 

--- a/src/visiumlint/main.py
+++ b/src/visiumlint/main.py
@@ -6,7 +6,10 @@ from subprocess import run
 import typer
 
 
-def lint(check_lint: bool = typer.Option(False, "--check", help="Enable check mode."), hook : bool = typer.Option(False, "--hook", help="Enable hook mode.")) -> None:
+def lint(
+    check_lint: bool = typer.Option(False, "--check", help="Enable check mode."),
+    hook: bool = typer.Option(False, "--hook", help="Enable hook mode."),
+) -> None:
     """Implement the logic of the lint command."""
     if check_lint:
         check_lint = "--check"

--- a/src/visiumlint/main.py
+++ b/src/visiumlint/main.py
@@ -6,7 +6,7 @@ from subprocess import run
 import typer
 
 
-def lint(check_lint: bool = typer.Option(False, "--check", help="Enable check mode.")) -> None:
+def lint(check_lint: bool = typer.Option(False, "--check", help="Enable check mode."), hook : bool = typer.Option(False, "--hook", help="Enable hook mode.")) -> None:
     """Implement the logic of the lint command."""
     if check_lint:
         check_lint = "--check"
@@ -21,21 +21,24 @@ def lint(check_lint: bool = typer.Option(False, "--check", help="Enable check mo
         ["sh", "-c", f"isort {check_lint} --gitignore . --line-length 120 --profile black"], check=False
     ).returncode
 
-    run(["sh", "-c", "echo Running pylint"], check=False)
-    pylint_returncode = run(
-        [
-            "sh",
-            "-c",
-            "pylint . --recursive=y --load-plugins=pylint.extensions.docstyle,pylint.extensions.docparams --disable=fixme,too-few-public-methods",
-            "--variable-rgx",
-            "^[a-z][a-z0-9_]*$",
-            "--argument-rgx",
-            "^[a-z][a-z0-9_]*$",
-            "--max-line-length",
-            "120",
-        ],
-        check=False,
-    ).returncode
+    if not hook:
+        run(["sh", "-c", "echo Running pylint"], check=False)
+        pylint_returncode = run(
+            [
+                "sh",
+                "-c",
+                "pylint . --recursive=y --load-plugins=pylint.extensions.docstyle,pylint.extensions.docparams --disable=fixme,too-few-public-methods",
+                "--variable-rgx",
+                "^[a-z][a-z0-9_]*$",
+                "--argument-rgx",
+                "^[a-z][a-z0-9_]*$",
+                "--max-line-length",
+                "120",
+            ],
+            check=False,
+        ).returncode
+    else:
+        pylint_returncode = 0
 
     run(["sh", "-c", "echo Running pydocstyle"], check=False)
     pydocstyle_returncode = run(


### PR DESCRIPTION
It is now possible to add visiumlint as a pre-commit hook.

The following changes were made:
- Added a --hook argument. This boolean argument, which is set to False by default, will not run Pylint when set to true. This was done since the the pre-commit runs visiumlint from an isolated virtualenv. Many of pylint's checks perform dynamic analysis which will fail there (such as imports). The hook still runs Pylint but as a local hook. This is specified in the `.pre-commit-config.yaml` file.
- Added a `.pre-commit-hooks.yaml` file containing the pre-commit that executes visiumlint without Pylint
- Modified the ReadMe to explain how to use the hook.
 
