### PR TITLE
added list of paths to visiumlint argument

### DIFF
--- a/src/visiumlint/main.py
+++ b/src/visiumlint/main.py
@@ -1,27 +1,34 @@
 """visiumlint main module."""
 # pylint: disable=duplicate-code
 import sys
+from pathlib import Path
 from subprocess import run
+from typing import List
 
 import typer
 
 
 def lint(
+    paths: List[Path] = typer.Argument(default=None, help="Paths of files and directories to visiumlint."),
     check_lint: bool = typer.Option(False, "--check", help="Enable check mode."),
     hook: bool = typer.Option(False, "--hook", help="Enable hook mode."),
 ) -> None:
     """Implement the logic of the lint command."""
+    if not paths:
+        paths = [Path(".")]
     if check_lint:
         check_lint = "--check"
     else:
         check_lint = ""
 
+    paths = " ".join([str(path) for path in paths if path.is_file() or path.is_dir()])
+
     run(["sh", "-c", "echo 'Running black'"], check=False)
-    black_returncode = run(["sh", "-c", f"black {check_lint} . --line-length 120"], check=False).returncode
+    black_returncode = run(["sh", "-c", f"black {paths} {check_lint} --line-length 120"], check=False).returncode
 
     run(["sh", "-c", "echo Running isort"], check=False)
     isort_returncode = run(
-        ["sh", "-c", f"isort {check_lint} --gitignore . --line-length 120 --profile black"], check=False
+        ["sh", "-c", f"isort {check_lint} --gitignore {paths} --line-length 120 --profile black"], check=False
     ).returncode
 
     if not hook:
@@ -30,7 +37,7 @@ def lint(
             [
                 "sh",
                 "-c",
-                "pylint . --recursive=y --load-plugins=pylint.extensions.docstyle,pylint.extensions.docparams --disable=fixme,too-few-public-methods",
+                f"pylint {paths} --recursive=y --load-plugins=pylint.extensions.docstyle,pylint.extensions.docparams --disable=fixme,too-few-public-methods",
                 "--variable-rgx",
                 "^[a-z][a-z0-9_]*$",
                 "--argument-rgx",
@@ -45,7 +52,8 @@ def lint(
 
     run(["sh", "-c", "echo Running pydocstyle"], check=False)
     pydocstyle_returncode = run(
-        ["sh", "-c", "pydocstyle .", "--add-ignore", "D107, D104, D103", "--convention", "google"], check=False
+        ["sh", "-c", f"pydocstyle {paths}", "--add-ignore", "D107, D104, D103", "--convention", "google"],
+        check=False,
     ).returncode
 
     run(["sh", "-c", "echo Running mypy"], check=False)
@@ -53,7 +61,7 @@ def lint(
         [
             "sh",
             "-c",
-            '! mypy . --disallow-untyped-defs --disallow-incomplete-defs | grep "Function is missing" || false',
+            f'! mypy {paths} --disallow-untyped-defs --disallow-incomplete-defs | grep "Function is missing" || false',
         ],
         check=False,
     ).returncode


### PR DESCRIPTION
Visiumlint currenlty lints all the files of the current directory.

With this feature, we are now able to specify a list of files/directories in the CLI. This is a common feature of linters such as Black, Pylint, etc.

By default, if no path is given, it still lints all the files of the current directory.