### PR TITLE
pre-commit hook now only acts on staged changes

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,4 @@
   description: Run visiumlint without Pylint
   entry: visiumlint --hook
   language: python
-  pass_filenames: false
+  pass_filenames: true


### PR DESCRIPTION
The pre-commit hook now only acts on staged changes, and no more on all files.